### PR TITLE
Hyperlink DOIs to preferred resolver

### DIFF
--- a/src/WebsiteTools.hs
+++ b/src/WebsiteTools.hs
@@ -41,7 +41,7 @@ lk u t = a_ [href_ u, target_ "_blank"] t
 
 doiToLink :: Text -> Html ()
 doiToLink d = lk lnk "DOI link"
-  where lnk = "http://dx.doi.org/" <> d
+  where lnk = "https://doi.org/" <> d
 
 sHtml :: (Show a, Monad m) => a -> HtmlT m ()
 sHtml = toHtml . show

--- a/src/papers.yaml
+++ b/src/papers.yaml
@@ -190,7 +190,7 @@
     volume: 2
     journal: Ergo
     number: 13
-  paperUrl: http://dx.doi.org/10.3998/ergo.12405314.0002.013
+  paperUrl: https://doi.org/10.3998/ergo.12405314.0002.013
   pubData:
     startPage: 299
     endPage: 328

--- a/src/writing.hs
+++ b/src/writing.hs
@@ -293,7 +293,7 @@ writing = [ A (Article
               "Comparing substructural theories of truth"
               "Ergo"
               Solo
-              "http://dx.doi.org/10.3998/ergo.12405314.0002.013"
+              "https://doi.org/10.3998/ergo.12405314.0002.013"
               (APD 2015 2 (Just 13) 299 328 "10.3998/ergo.12405314.0002.013")
               "ripley:cstt"
               (Just "Substructural theories of truth are theories based on logics that do not include the full complement of usual structural rules. Existing substructural approaches fall into two main families: noncontractive approaches and nontransitive approaches. This paper provides a sketch of these families, and argues for two claims: first, that substructural theories are better-positioned than other theories to grapple with the truth-theoretic paradoxes, and second---more tentatively---that nontransitive approaches are in turn better-positioned than noncontractive approaches."))


### PR DESCRIPTION
Hello :-)

The DOI foundation recommends [this new resolver](https://www.doi.org/doi_handbook/3_Resolution.html#3.8). It may be a bit ironic that they would change the URL of their service, but it's now [encrypted](https://www.ssllabs.com/ssltest/analyze.html?d=doi.org). Because the old `dx` subdomain is being redirected, there is no urgent need to do anything.

However, I'd hereby like to suggest to follow the new recommendation by applying this update to all static DOI links and the code that generates new DOI links.

Cheers!